### PR TITLE
Add support for Microsoft C/C++ compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ Supported compilers:
 - GCC from version 4.8 onward
 - Clang from version 9.0 onward
 - AppleClang from version 11.0.3 (included in Xcode version 11.4) onward
+- Microsoft C/C++ compiler 19.29 (included in Visual Studio 2019 version 16.10) onward
 
 On unsupported compilers, the output will be as follows:
 
 - The `file_name()` and `function_name()` will display 'unsupported'
 - The `line()` and `column()` will display '0'
 
-The `column()` functionality is exclusively supported on Clang.
+The `column()` functionality is only supported on Clang and Microsoft.
 
 ## Usage
 

--- a/include/source_location/source_location.hpp
+++ b/include/source_location/source_location.hpp
@@ -23,6 +23,13 @@
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FUNCTION
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_LINE
 #define NOSTD_SOURCE_LOCATION_NO_BUILTIN_COLUMN
+// Microsoft Visual Studio: builtin supports starts with 2019 16.10 Preview 2
+// https://github.com/microsoft/STL/pull/664
+#elif defined(_MSC_VER) and (_MSC_VER >= 1929)
+#define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FILE
+#define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FUNCTION
+#define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_LINE
+#define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_COLUMN
 #endif
 
 namespace nostd {


### PR DESCRIPTION
This PR extends the header to enable builtins on supported Microsoft compilers.

According to [this issue](https://github.com/microsoft/STL/issues/54) support was added with MSVS 2019 16.10 Preview 2 and I've used `_MSC_VER >= 1929` based on [this list](https://learn.microsoft.com/en-us/cpp/overview/compiler-versions?view=msvc-170#service-releases-starting-with-visual-studio-2017).

Having said that I have no means to verify that the chosen value is correct. However, I'm on 1939 and I can confirm that this change works in C++17 mode.
I could not run the tests because CMake scripts are lacking MSVC support.