### PR TITLE
Add MSVC support

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -78,9 +78,39 @@ jobs:
               xcode-version: "15.0.1",
               c_compiler: "clang", cpp_compiler: "clang++"
             }
+          - {
+              name: "Windows Server 2019 VS-16.5",
+              os: windows-2019, vs_version: "16.0",
+              build_type: Release,
+              c_compiler: "cl", cpp_compiler: "cl"
+            }
+          - {
+              name: "Windows Server 2019 VS-16.5 (clang-cl)",
+              os: windows-2019, vs_version: "16.0",
+              build_type: Release,
+              c_compiler: "clang-cl", cpp_compiler: "clang-cl",
+              cmake_extra_commands: "-T ClangCL"
+            }
+          - {
+              name: "Windows Server 2022 VS-17.9",
+              os: windows-2022, vs_version: "17.0",
+              build_type: Release,
+              c_compiler: "cl", cpp_compiler: "cl"
+            }
+          - {
+              name: "Windows Server 2022 VS-17.9 (clang-cl)",
+              os: windows-2022, vs_version: "17.0",
+              build_type: Release,
+              c_compiler: "clang-cl", cpp_compiler: "clang-cl",
+              cmake_extra_commands: "-T ClangCL"
+            }
 
     steps:
     - uses: actions/checkout@v4
+    - uses: ilammy/msvc-dev-cmd@v1
+      if: runner.os == 'Windows'
+      with:
+        vsversion: ${{ matrix.config.vs_version }}
 
     - name: Install apt packages
       if: runner.os == 'Linux'
@@ -94,6 +124,12 @@ jobs:
       run: |
         brew update
         echo "ninja" | xargs -n 1 brew install
+      shell: sh
+
+    - name: Install choco packages
+      if: runner.os == 'Windows'
+      run: |
+        choco install ninja pkgconfiglite
       shell: sh
 
     - name: Setup build environment
@@ -124,6 +160,7 @@ jobs:
         -DSOURCE_LOCATION_BUILD_TESTS=false
         -DCMAKE_INSTALL_PREFIX=${{ steps.build_env.outputs.prefix_root }}
         -S ${{ steps.build_env.outputs.library-source-dir }}
+        ${{ matrix.config.cmake_extra_commands }}
 
     - name: Install nonstd::source_location
       run: cmake --build ${{ steps.build_env.outputs.library-build-output-dir }} --target install --config ${{ matrix.config.build_type }}
@@ -137,13 +174,15 @@ jobs:
         -DEXAMPLES_USE_CMAKE_CMAKE_CONFIG=true
         -DCMAKE_PREFIX_PATH=${{ steps.build_env.outputs.prefix_root }}
         -S ${{ steps.build_env.outputs.examples-source-dir }}
+        ${{ matrix.config.cmake_extra_commands }}
 
     - name: Build showcase application (nonstd::source_location exported cmake target)
       run: cmake --build ${{ steps.build_env.outputs.examples-with-exported-cmake-build-output-dir }} --config ${{ matrix.config.build_type }}
 
     - name: Run showcase application (nonstd::source_location exported cmake target)
+      shell: sh
       working-directory: ${{ steps.build_env.outputs.examples-with-exported-cmake-build-output-dir }}
-      run: ./source_location_example.app
+      run: ./bin/source_location_example.app
 
     - name: Configure showcase application CMake (nonstd::source_location pkg-config .pc file)
       run: >
@@ -153,10 +192,12 @@ jobs:
         -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
         -DCMAKE_PREFIX_PATH=${{ steps.build_env.outputs.prefix_root }}
         -S ${{ steps.build_env.outputs.examples-source-dir }}
+        ${{ matrix.config.cmake_extra_commands }}
 
     - name: Build showcase application (nonstd::source_location pkg-config .pc file)
       run: cmake --build ${{ steps.build_env.outputs.examples-with-pkg-config-build-output-dir }} --config ${{ matrix.config.build_type }}
 
     - name: Run showcase application (nonstd::source_location pkg-config .pc file)
+      shell: sh
       working-directory: ${{ steps.build_env.outputs.examples-with-pkg-config-build-output-dir }}
-      run: ./source_location_example.app
+      run: ./bin/source_location_example.app

--- a/.github/workflows/ut.yml
+++ b/.github/workflows/ut.yml
@@ -78,9 +78,39 @@ jobs:
               xcode-version: "15.0.1",
               c_compiler: "clang", cpp_compiler: "clang++"
             }
+          - {
+              name: "Windows Server 2019 VS-16.11",
+              os: windows-2019, vs_version: "16.0",
+              build_type: Debug,
+              c_compiler: "cl", cpp_compiler: "cl"
+            }
+          - {
+              name: "Windows Server 2019 VS-16.11 (clang-cl)",
+              os: windows-2019, vs_version: "16.0",
+              build_type: Debug,
+              c_compiler: "clang-cl", cpp_compiler: "clang-cl",
+              cmake_extra_commands: "-T ClangCL"
+            }
+          - {
+              name: "Windows Server 2022 VS-17.9",
+              os: windows-2022, vs_version: "17.0",
+              build_type: Debug,
+              c_compiler: "cl", cpp_compiler: "cl"
+            }
+          - {
+              name: "Windows Server 2022 VS-17.9 (clang-cl)",
+              os: windows-2022, vs_version: "17.0",
+              build_type: Debug,
+              c_compiler: "clang-cl", cpp_compiler: "clang-cl",
+              cmake_extra_commands: "-T ClangCL"
+            }
 
     steps:
     - uses: actions/checkout@v4
+    - uses: ilammy/msvc-dev-cmd@v1
+      if: runner.os == 'Windows'
+      with:
+        vsversion: ${{ matrix.config.vs_version }}
 
     - name: Install apt packages
       if: runner.os == 'Linux'
@@ -94,6 +124,12 @@ jobs:
       run: |
         brew update
         echo "ninja" | xargs -n 1 brew install
+      shell: sh
+
+    - name: Install choco packages
+      if: runner.os == 'Windows'
+      run: |
+        choco install ninja
       shell: sh
 
     - name: Setup build environment
@@ -117,6 +153,7 @@ jobs:
         -DCMAKE_C_COMPILER=${{ matrix.config.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
         -S ${{ steps.build_env.outputs.source-dir }}
+        ${{ matrix.config.cmake_extra_commands }}
 
     - name: Build
       run: cmake --build ${{ steps.build_env.outputs.build-output-dir }} --config ${{ matrix.config.build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.6)
 project(
   source_location
   LANGUAGES CXX
-  VERSION 0.3)
+  VERSION 0.4)
 
 if(CMAKE_BINARY_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   message(
@@ -30,7 +30,16 @@ endif()
 set(SOURCE_LOCATION_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(SOURCE_LOCATION_HEADERS_DIR ${SOURCE_LOCATION_DIR}/include/)
 
-add_compile_options(-Wall -Wextra -pedantic -Werror)
+# When CMake v3.26 will be incorporated check for empty
+# CMAKE_CXX_COMPILER_FRONTEND_VARIANT can be removed
+# https://cmake.org/cmake/help/v3.26/variable/CMAKE_LANG_COMPILER_FRONTEND_VARIANT.html
+add_compile_options(
+  "$<$<AND:$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>,$<OR:$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},GNU>,$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},>>>:-Werror;-Wall;-Wextra;-pedantic>"
+)
+
+add_compile_options(
+  "$<$<AND:$<COMPILE_LANG_AND_ID:CXX,MSVC,Clang>,$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},MSVC>>:/WX;/W4>"
+)
 
 if(SOURCE_LOCATION_BUILD_TESTS)
   enable_testing()

--- a/README.md
+++ b/README.md
@@ -14,19 +14,21 @@ Supported platforms:
 
 - Linux
 - macOS
+- Windows
 
 Supported compilers:
 
 - GCC from version 4.8 onward
 - Clang from version 9.0 onward
 - AppleClang from version 11.0.3 (included in Xcode version 11.4) onward
+- MSVC (including clang-cl) from version 19.26 (included in Visual Studio 2019 version 16.6) onward
 
 On unsupported compilers, the output will be as follows:
 
 - The `file_name()` and `function_name()` will display 'unsupported'
 - The `line()` and `column()` will display '0'
 
-The `column()` functionality is exclusively supported on Clang.
+The `column()` functionality is not supported on GCC.
 
 ## Usage
 
@@ -113,12 +115,14 @@ Platforms:
 
 - Linux
 - Mac
+- Windows
 
 Compilers:
 
 - Clang 10/11/12/13/14/15
 - GCC 9/10/11/12
 - Xcode 15.0.1
+- MSVC (including clang-cl) 16.11/17.9
 
 Previously verified compilers on Travis CI:
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,20 +3,29 @@ project(source_location_examples)
 
 set(CMAKE_CXX_STANDARD 11)
 
+# generator expression to affect Multi-configuration generators like Visual
+# Studio, Ninja Multi-Config
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY $<1:${CMAKE_BINARY_DIR}/lib>)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_BINARY_DIR}/lib>)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_BINARY_DIR}/bin>)
+
 set(EXAMPLE_APPLICATION_SOURCES example_app.cpp)
 
-add_executable(source_location_example.app ${EXAMPLE_APPLICATION_SOURCES})
+add_executable(source_location_example ${EXAMPLE_APPLICATION_SOURCES})
+
+set_target_properties(
+  source_location_example PROPERTIES OUTPUT_NAME "source_location_example"
+                                     SUFFIX ".app")
 
 if(EXAMPLES_USE_CMAKE_CMAKE_CONFIG)
   message("Using exported cmake config.")
   find_package(source_location CONFIG REQUIRED)
-  target_link_libraries(source_location_example.app
-                        PUBLIC nostd::source_location)
+  target_link_libraries(source_location_example PUBLIC nostd::source_location)
 else()
   message("Using PkgConfig.")
   find_package(PkgConfig REQUIRED)
   pkg_check_modules(PKG_SOURCE_LOCATION REQUIRED IMPORTED_TARGET
                     source_location)
-  target_link_libraries(source_location_example.app
+  target_link_libraries(source_location_example
                         PUBLIC PkgConfig::PKG_SOURCE_LOCATION)
 endif()

--- a/include/source_location/source_location.hpp
+++ b/include/source_location/source_location.hpp
@@ -6,34 +6,40 @@
 #include <cstdint>
 
 // Clang
-#if not defined(__apple_build_version__) and defined(__clang__) and (__clang_major__ >= 9)
+#if defined(__clang__) && !defined(__apple_build_version__) && (__clang_major__ >= 9)
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FILE
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FUNCTION
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_LINE
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_COLUMN
 // AppleClang https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
-#elif defined(__apple_build_version__) and defined(__clang__) and (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__ % 100) >= 110003
+#elif defined(__apple_build_version__) && defined(__clang__) && (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__ % 100) >= 110003
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FILE
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FUNCTION
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_LINE
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_COLUMN
 // GCC
-#elif defined(__GNUC__) and (__GNUC__ > 4 or (__GNUC__ == 4 and __GNUC_MINOR__ >= 8))
+#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8))
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FILE
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FUNCTION
 #define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_LINE
 #define NOSTD_SOURCE_LOCATION_NO_BUILTIN_COLUMN
+// MSVC https://github.com/microsoft/STL/issues/54#issuecomment-616904069 https://learn.microsoft.com/en-us/cpp/overview/compiler-versions?view=msvc-170
+#elif defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER) && (_MSC_VER >= 1926)
+#define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FILE
+#define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FUNCTION
+#define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_LINE
+#define NOSTD_SOURCE_LOCATION_HAS_BUILTIN_COLUMN
 #endif
 
 namespace nostd {
 struct source_location {
 public:
-#if defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FILE) and defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FUNCTION) and defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_LINE) and defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_COLUMN)
+#if defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FILE) && defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FUNCTION) && defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_LINE) && defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_COLUMN)
     static constexpr source_location current(const char* fileName = __builtin_FILE(),
         const char* functionName = __builtin_FUNCTION(),
         const uint_least32_t lineNumber = __builtin_LINE(),
         const uint_least32_t columnOffset = __builtin_COLUMN()) noexcept
-#elif defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FILE) and defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FUNCTION) and defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_LINE) and defined(NOSTD_SOURCE_LOCATION_NO_BUILTIN_COLUMN)
+#elif defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FILE) && defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_FUNCTION) && defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_LINE) && defined(NOSTD_SOURCE_LOCATION_NO_BUILTIN_COLUMN)
     static constexpr source_location current(const char* fileName = __builtin_FILE(),
         const char* functionName = __builtin_FUNCTION(),
         const uint_least32_t lineNumber = __builtin_LINE(),

--- a/tests/source_location_tests.cpp
+++ b/tests/source_location_tests.cpp
@@ -20,9 +20,9 @@ static_assert(std::is_nothrow_destructible<nostd::source_location>::value, "is_n
 
 static_assert(std::is_nothrow_move_constructible<nostd::source_location>::value, "is_nothrow_move_constructible<nostd::source_location> false");
 static_assert(std::is_nothrow_move_assignable<nostd::source_location>::value, "is_nothrow_move_assignable<nostd::source_location> false");
-#if not defined(__apple_build_version__)
+#if !defined(__apple_build_version__) && !defined(_MSC_VER)
 static_assert(std::is_nothrow_swappable<nostd::source_location>::value, "is_nothrow_swappable<nostd::source_location> false");
-#else
+#elif defined(__apple_build_version__)
 static_assert(std::__is_nothrow_swappable<nostd::source_location>::value, "__is_nothrow_swappable<nostd::source_location> false");
 #endif
 
@@ -139,7 +139,8 @@ void test_source_location_current()
 #endif
 
 #if defined(NOSTD_SOURCE_LOCATION_HAS_BUILTIN_COLUMN)
-    REQUIRE(sourceLocation.column() == 33);
+    // MSVC and Clang __builtin_COLUMN() return different values
+    REQUIRE(sourceLocation.column() != 0);
 #else
     REQUIRE(sourceLocation.column() == 0);
 #endif


### PR DESCRIPTION
- add MSVC support starting from version 19.26
- change source_location version to 0.4
- add msvc /W4 /WX compilation flags
- add clang-cl frontend variant in cmake files
- fix warning C4067 on msvc (and/or -> &&/|| in #ifs)
- add windows CI build and verification jobs for MSVC (including clang-cl)